### PR TITLE
custom ijrq suffix

### DIFF
--- a/lua/moran_express_translator.lua
+++ b/lua/moran_express_translator.lua
@@ -36,6 +36,7 @@ function top.init(env)
    env.ijrq_enable = env.engine.schema.config:get_bool("moran/ijrq/enable")
    env.ijrq_defer = env.engine.schema.config:get_int("moran/ijrq/defer") or env.engine.schema.config:get_int("menu/page_size") or 5
    env.ijrq_hint = env.engine.schema.config:get_bool("moran/ijrq/show_hint")
+   env.ijrq_suffix = env.engine.schema.config:get_string("moran/ijrq/suffix")
    env.enable_word_filter = env.engine.schema.config:get_bool("moran/enable_word_filter")
 end
 
@@ -102,7 +103,7 @@ function top.func(input, seg, env)
          -- 啓用出簡讓全時
          local ijrq_enabled = true
             and (env.engine.context.input == input)
-            and ((input_len == 4) or (input_len == 5 and input:sub(5,5) == 'o'))
+            and ((input_len == 4) or (input_len == 5 and input:sub(5,5) == env.ijrq_suffix))
          local immediate_set = {}
          local deferred_set = {}
          for cand in smart_iter do

--- a/moran.schema.yaml
+++ b/moran.schema.yaml
@@ -276,6 +276,7 @@ moran:  # 兜底默認值；以防用戶不提供任何值
     enable: true
     #defer: 5
     show_hint: false
+    suffix: 'o'
 
 __patch:
   - moran.defaults.yaml:/patch?


### PR DESCRIPTION
在lua中实现自定义出简让全的后缀

方便不想使用 `o` 作为后缀的用户直接在方案配置的 `moran/ijrq/suffix` 中修改

示例： 
用 `;` 作为出简让全后缀：
```yaml
moran:  # 兜底默認值；以防用戶不提供任何值
  quick_code_indicator: "⚡️"
  enable_word_filter: false
  ijrq:
    enable: true
    #defer: 5
    show_hint: false
    suffix: ';'
```