### PR TITLE
魔然并击

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -8,6 +8,7 @@ schema_list:
   - schema: moran_fixed
   - schema: moran_sentence
   - schema: moran_aux
+  - schema: moran_bj
   - schema: tiger
   # - schema: luna_pinyin
   # - schema: luna_pinyin_simp

--- a/moran_bj.schema.yaml
+++ b/moran_bj.schema.yaml
@@ -1,0 +1,330 @@
+schema:
+  schema_id: moran_bj
+  name: 魔然并击版
+  version: "20240115"
+  author:
+    - 自然碼發明人：周志農
+    - 方案製作：ksqsf
+    - 双拼并击方案 gaboolic
+  description: |
+    双拼并击原理：把右手上左手没有的键，映射到左手，左手键映射到右手。让左手能控制23个声母，右手能控制24个韵母，并击字母表改为左手的字母在前，这样即可保证声母在前，并击不会乱序。例如皮，p在右手需要映射到左手，用qf，所以并击qf就出现p，并击qfi 就出现皮么，m在右手，e在左手，正好相反。需要并击ac出m 并击ji出e，并击acji出么。映射规则基本上就是镜像一下再加个字母，例如yuio镜像到左手分别是trew加上a，p是q加上f
+  dependencies:
+    - moran_fixed
+    - moran_sentence
+    - moran_reverse
+    - moran_english
+    #- moran_japanese # 日語混輸
+    - stroke
+    - tiger
+    - cangjie5
+    - zrlf
+
+switches:
+  - name: ascii_mode
+    states: [ 中文, 西文 ]
+  - name: full_shape
+    states: [ 半角, 全角 ]
+  - name: simplification
+    states: [ 漢字, 汉字 ]
+  - name: ascii_punct
+    states: [ 。，, ．， ]
+  - options: [ gbk+emoji, utf8, big5+emoji ]
+    states: [ GBK, UTF-8, BIG5 ]
+  - name: inflexible
+    states: [ 動詞, 固詞 ] # 「固詞」表示「固頂詞」
+    # 默認情況下，輸入 4 碼時，會禁止碼表輸出（「動詞」模式）。
+    # 這是因爲碼表最大碼長爲 4，可能會產生較低頻的多字詞，覆蓋過用戶自造的常用詞語。
+    # 當固詞模式啓動後，輸入 4 碼時會優先輸出碼表中的二字詞，這些輸出帶有「⚡️」標記。
+  - name: emoji
+    states: [ 🈚, 🈶 ]
+  - name: unicode_comment
+    states: [ U關, U開 ]
+  - options: [ std_opencc,  std_tw, std_hk, std_dzing ]
+    states: [ 通, 臺, 港, 寍 ]
+
+engine:
+  processors:
+    - key_binder
+    - lua_processor@*moran_semicolon_processor
+    - ascii_composer
+    - chord_composer
+    - recognizer
+    - speller
+    - punctuator
+    - lua_processor@*moran_launcher     # 輸入 omorj 或 ogrwh 後回車打開魔然官網
+    - selector
+    - navigator
+    - express_editor
+  segmentors:
+    - ascii_segmentor
+    - matcher
+    - abc_segmentor
+    - punct_segmentor
+    - fallback_segmentor
+  translators:
+    - punct_translator
+    - reverse_lookup_translator@reverse_universal
+    - reverse_lookup_translator@reverse_tiger
+    - reverse_lookup_translator@reverse_stroke
+    - reverse_lookup_translator@reverse_cangjie5
+    - reverse_lookup_translator@reverse_zrlf
+    - table_translator@custom_phrase       # 自定義短語
+    - table_translator@english             # 英語混輸
+    #- table_translator@japanese            # 日語混輸
+    - lua_translator@*moran_express_translator@with_reorder # 翻譯器
+    - lua_translator@*moran_shijian        # 日期orq 節氣ojq 星期oxq 時間osj
+    - lua_translator@*moran_number         # 數字轉大寫
+  filters:
+    - lua_filter@*moran_reorder_filter
+    - lua_filter@*moran_aux_hint
+    - lua_filter@*moran_quick_code_hint
+    - simplifier@emoji
+    - charset_filter@gbk+emoji
+    - charset_filter@big5+emoji
+    - simplifier@std_hk
+    - simplifier@std_tw
+    - simplifier@std_dzing
+    - simplifier
+    - lua_filter@*moran_charset_comment_filter  # Unicode 區位提示
+    - lua_filter@*moran_unicode_display_filter  # Unicode 編碼提示
+    - uniquifier
+
+speller:
+  alphabet: abcdefghijklmnopqrstuvwxyz
+  delimiter: " '"
+  algebra:
+    __patch:
+      - moran:/algebra/user_force_top?
+      - moran:/algebra/user_sentence_top?
+      - moran:/algebra/generate_code
+      - moran:/algebra/user_sentence_bottom?
+      - moran:/algebra/user_force_bottom?
+
+chord_composer:
+  # 字母表，包含用并击按键
+  # 击键一律以字母表顺序排列
+  alphabet: "aqzswxdecfrvgtbhynjumki,lo.;p',./"
+  algebra:
+    # - "xform/^,$/,/"
+    # - "xform/^\.$/./"
+    # 定义左手11键       
+    - xform/^at(?![左右])/y左/
+    - xform/^ar(?![左右])/u左/
+    - xform/^ae(?![左右])/i左/
+    - xform/^aw(?![左右])/o左/
+    - xform/^qf(?![左右])/p左/
+    - xform/^as(?![左右])/l左/
+    - xform/^ad(?![左右])/k左/
+    - xform/^af(?![左右])/j左/
+    - xform/^ag(?![左右])/h左/
+    - xform/^ac(?![左右])/m左/
+    - xform/^av(?![左右])/n左/
+
+    # 定义右手15键
+    - xform/jp(?![左右])$/q右/
+    - xform/jo(?![左右])$/w右/
+    - xform/ji(?![左右])$/e右/
+    - xform/ul(?![左右])$/r右/
+    - xform/yl(?![左右])$/t右/
+    - xform/l;(?![左右])$/s右/
+    - xform/kl(?![左右])$/d右/
+    - xform/jk(?![左右])$/f右/
+    - xform/hl(?![左右])$/g右/    
+    - xform/mk(?![左右])$/z右/
+    - xform/nk(?![左右])$/x右/
+    - xform/ml(?![左右])$/c右/
+    - xform/nl(?![左右])$/v右/
+    - xform/ni(?![左右])$/b右/
+    - xform/;(?![左右])$/a右/
+  # 并击完成后套用式样
+  output_format:
+    - "xform/^(.*)左/$1/"
+    - "xform/^(.*)右$/$1/"
+    - "xform/^(.*)左(.*)右$/$1$2/"
+      
+ # 并击过程中套用式样  
+  prompt_format:
+    # 加方括号
+    - "xform/^(.*)$/[$1]/" 
+
+translator:    # 整句輸入模式設置，在 top_translator 中被調用
+  dictionary: moran.extended
+  prism: moran
+  initial_quality: 5
+  max_homophones: 7
+  spelling_hints: 3
+  contextual_suggestions: true
+  preedit_format:
+    - xform/([a-z][a-z][a-z][a-z])o/$1°/
+
+fixed:         # 固頂輸入模式設置，在 top_translator 中被調用
+  dictionary: moran_fixed
+  initial_quality: 100
+  enable_completion: false
+  enable_sentence: false
+  enable_user_dict: false
+  enable_encoder: false
+  encode_commit_history: true
+
+custom_phrase: # 自定義短語
+  dictionary: ""
+  user_dict: moran_custom_phrases
+  db_class: stabledb
+  enable_completion: false
+  enable_sentence: false
+  initial_quality: 1000
+
+english:
+  dictionary: moran_english
+  enable_completion: true
+  enable_sentence: false
+  enable_user_dict: true
+  initial_quality: 1
+  enable_encoder: false
+  encode_commit_history: false
+  comment_format:
+    - xform/.*//
+
+japanese:
+  dictionary: moran_japanese
+  enable_completion: false
+  enable_sentence: true
+  enable_user_dict: true
+  initial_quality: 0
+  enable_encoder: false
+  encode_commit_history: false
+  comment_format:
+    - xform/.*//
+
+simplifier:
+  option_name: simplification
+  opencc_config: moran_t2s.json
+
+emoji:
+  opencc_config: moran_emoji.json
+  option_name: emoji
+  tips: none
+
+std_hk:
+  opencc_config: t2hk.json
+  option_name: std_hk
+  #tips: all
+
+std_tw:
+  opencc_config: t2tw.json
+  option_name: std_tw
+  #tips: all
+
+std_dzing:
+  opencc_config: moran_dzing.json
+  option_name: std_dzing
+  tips: all
+
+reverse_format:
+  comment_format:
+    - xform/(\w\w);(\w\w)/$1[$2]/
+  preedit_format:
+    - xform/^o(lf|bh|cj)//
+
+reverse_tiger:
+  tag: reverse_tiger
+  dictionary: tiger
+  enable_completion: true
+  prefix: "`"
+  tips: 〔虎碼〕
+  __include: reverse_format
+
+reverse_universal:
+  tag: reverse_universal
+  dictionary: moran.chars
+  tips: 〔通配〕
+  __include: reverse_format
+
+reverse_stroke:
+  tag: reverse_stroke
+  dictionary: stroke
+  prefix: "obh"
+  enable_completion: true
+  tips: 〔橫h豎s撇p捺n折z〕
+  __include: reverse_format
+
+reverse_cangjie5:
+  tag: reverse_cangjie5
+  dictionary: cangjie5
+  prefix: "ocj"
+  enable_completion: true
+  tips: 〔倉頡五代〕
+  __include: reverse_format
+
+reverse_zrlf:
+  tag: reverse_zrlf
+  dictionary: zrlf
+  prefix: "olf"
+  enable_completion: true
+  tips: 〔兩分〕
+  __include: reverse_format
+
+reverse_lookup:
+  extra_tags:
+    - reverse_tiger
+    - reverse_universal
+    - reverse_stroke
+    - reverse_cangjie5
+    - reverse_zrlf
+
+punctuator:
+  import_preset: symbols
+
+key_binder:
+  import_preset: default
+  bindings:
+    __patch:
+      - moran:/key_bindings/moran_capital_for_last_syllable
+      - moran:/key_bindings/moran_tab
+      - moran:/key_bindings/moran_switches
+
+recognizer:
+  import_preset: default
+  patterns:
+    reverse_universal: "(^(`[a-z`]+))|(^([a-z]{2}(`[a-z`]?|[a-z`]`)))"
+    reverse_tiger: "(^`$)|(^`[a-zA-Z]+$)"
+    reverse_stroke: "^obh[A-Za-z]*$"
+    reverse_cangjie5: "^ocj[A-Za-z]*$"
+    reverse_zrlf: "^olf[A-Za-z]*$"
+    punct: '^/([0-9]0?|[A-Za-z]+)$'
+
+moran:
+  # 簡快碼提示符
+  # 修改爲 "" 可取消提示符
+  # 建議在熟悉簡碼後再取消
+  quick_code_indicator: "⚡️"
+
+  # 詞輔功能
+  # 當輸入二字或三字詞時，允許末輸入篩選詞語。
+  # 例如輸入 lmjxz 可以篩選「連接」。
+  # 但是與字輔輸入方法不同，詞輔在生效後 *不能* 在句末繼續輸入形成整
+  # 句——這個功能僅用於「篩選」。因此，這個功能僅適合習慣於以詞語爲單
+  # 位輸入的用戶。
+  enable_word_filter: false
+
+  # 「出簡讓全」相關設置
+  # 當一個字具有簡碼時，打其全碼（不論是 yyxx 還是 yyxxo）都會導致該
+  # 字讓出首位，而被推遲到後位。
+  ijrq:
+    enable: true       # 是否啓用出簡讓全？
+    #defer: 5          # 延遲多少位？若不設置该项，則默認值是推遲到第二頁
+    show_hint: true    # 若讓全，則提示簡碼打法
+
+  # 單字輔助碼提示
+  # 注：會顯示出所有可能的輔助碼
+  enable_aux_hint: false
+
+  # 簡快碼提示（包括字和詞）
+  # 例如 輸入 yy te er 英特爾 會提示「⚡yte」，即使用 yte 可以打出這個詞
+  enable_quick_code_hint: false
+
+# 默認啓用語言模型
+__include: moran:/octagram/enable_for_sentence
+# 若要禁用，在 custom 文件中寫入：
+# patch:
+#   __include: moran:/octagram/disable


### PR DESCRIPTION
增加了並擊

双拼并击原理：把右手上左手没有的键，映射到左手，左手键映射到右手。
让左手能控制23个声母，右手能控制24个韵母，并击字母表改为左手的字母在前，这样即可保证声母在前，并击不会乱序。

例如：
1 皮，p在右手需要映射到左手，用qf，所以并击qf就出现p，并击qfi 就出现皮
2 么，m在右手，e在左手，正好相反。需要并击ac出m 并击ji出e，并击acji出么。

映射规则基本上就是镜像一下再加个字母，例如yuio镜像到左手分别是trew加上a，p是q加上f
