### PR TITLE
fix(dict): 枡 dou -> shēng

### DIFF
--- a/moran.chars.dict.yaml
+++ b/moran.chars.dict.yaml
@@ -10850,7 +10850,7 @@ use_preset_vocabulary: false
 枟	yp;my	416
 枠	zv;mu	408
 枠	zv;mz	408
-枡	db;mu	550
+枡	ug;mu	550
 枢	qu;mq	0
 枢	uu;mq	0
 枣	zk;cd	0


### PR DESCRIPTION
● 枡 shēng ㄕㄥˉ ◎ 古人名用字。