### PR TITLE
移除混淆了「形」和「型」的部分錯詞

### DIFF
--- a/lua/moran_quick_code_hint.lua
+++ b/lua/moran_quick_code_hint.lua
@@ -10,7 +10,7 @@ function Module.init(env)
    else
       env.quick_code_hint_reverse = nil
    end
-   env.quick_code_indicator = env.engine.schema.config:get_string("moran/quick_code_indicator")
+   env.quick_code_indicator = env.engine.schema.config:get_string("moran/quick_code_indicator") or "⚡"
 end
 
 function Module.fini(env)
@@ -46,11 +46,11 @@ function Module.func(translation, env)
             end
             local codes_hint = table.concat(codes, " ")
             local comment = ""
-            if gcand.comment == env.quick_code_indicator and env.quick_code_indicator ~= "" then
+            if gcand.comment == env.quick_code_indicator then
                -- Avoid double ⚡
                comment = gcand.comment .. codes_hint
             else
-               comment = gcand.comment .. "⚡" .. codes_hint
+               comment = gcand.comment .. env.quick_code_indicator .. codes_hint
             end
             gcand.comment = comment
          end

--- a/lua/moran_quick_code_hint.lua
+++ b/lua/moran_quick_code_hint.lua
@@ -33,15 +33,19 @@ function Module.func(translation, env)
          yield(cand)
       else
          local all_codes = env.quick_code_hint_reverse:lookup(word)
+         local in_use = false
          if all_codes then
             local codes = {}
             for code in all_codes:gmatch("%S+") do
-               if #code < 4 -- and code ~= cand.preedit
-               then
-                  table.insert(codes, code)
+               if #code < 4 then
+                  if code == cand.preedit then
+                     in_use = true
+                  else
+                     table.insert(codes, code)
+                  end
                end
             end
-            if #codes == 0 then
+            if #codes == 0 and not in_use then
                goto continue
             end
             local codes_hint = table.concat(codes, " ")


### PR DESCRIPTION
有一些詞暫時不能確定到底是該用「型」還是「形」，這部分詞沒有改動。

裏面的幾種「鰕虎魚」是重複寫了多行，而不是混淆了「形」和「型」，不過也一併刪掉了多餘的行。