### PR TITLE
dict:去掉固顶码表的3码次选字、修正一个繁体字

### DIFF
--- a/moran_fixed_simp.dict.yaml
+++ b/moran_fixed_simp.dict.yaml
@@ -1618,7 +1618,7 @@ A4纸	asv
 绑紧	bhjn
 绑架	bhjw
 报户口	bhk
-𠳐	bhk
+𠳐	bhkb
 蚌壳	bhke
 帮困	bhkp
 不合理	bhl
@@ -2491,13 +2491,13 @@ A4纸	asv
 报名	bkmy
 胞妹	bkmz
 不可能	bkn
-鸨	bkn
 不可能吧	bknb
 不可能的	bknd
 包囊	bknh
 包年	bknm
 保暖	bknr
 暴虐	bknt
+鸨	bknu
 暴怒	bknu
 不可逆转	bknv
 暴	bko
@@ -3048,7 +3048,6 @@ A4纸	asv
 变坏	bmhy
 变黑	bmhz
 编程	bmi
-蝙	bmi
 变差	bmia
 蝙	bmib
 编创	bmid
@@ -4817,7 +4816,6 @@ B盘	bpj
 白族吹吹腔	bziq
 辈出	bziu
 背景	bzj
-钡	bzj
 钡	bzjb
 北郊	bzjc
 北疆	bzjd
@@ -7265,9 +7263,9 @@ C语言	cyy
 待办事项	dbux
 道不拾遗	dbuy
 对不住	dbv
-篼	dbv
 豆渣	dbva
 都不知道	dbvd
+篼	dbvd
 斗争	dbvg
 斗志	dbvi
 打不着狐狸惹身骚	dbvs
@@ -10258,9 +10256,9 @@ D盘	dpj
 大书特书	dutu
 大赦天下	dutx
 的身上	duu
-碡	duu
 毒杀	duua
 毒手	duub
+碡	duud
 毒蛇	duue
 独身	duuf
 独生	duug
@@ -11020,9 +11018,9 @@ D盘	dpj
 苊	eece
 萼	eeck
 涐	eed
-㓵	eed
 恶斗	eedb
 鹅蛋	eedj
+㓵	eedo
 讹夺	eedo
 鄂尔多斯	eeds
 额度	eedu
@@ -13127,7 +13125,6 @@ F盘	fpj
 浮厝	fuco
 服从	fucs
 副	fud
-负	fud
 负	fudb
 浮雕	fudc
 浮	fudf
@@ -13454,7 +13451,6 @@ F盘	fpj
 腹泻	fuxx
 复兴	fuxy
 袱	fuy
-讣	fuy
 府衙	fuya
 蜉蝣	fuyb
 放手一搏	fuyb
@@ -20301,7 +20297,6 @@ H盘	hpj
 胡瓜	hugw
 湖怪	hugy
 虎	huh
-虍	huh
 扈	huhb
 何时何地	huhd
 戽	huhd
@@ -25031,7 +25026,6 @@ I盘	ipj
 胶鞋	jcxx
 侥幸	jcxy
 仅次于	jcy
-酵	jcy
 脚丫	jcya
 交友	jcyb
 郊游	jcyb
@@ -26821,7 +26815,6 @@ I盘	ipj
 艰难曲折	jnqv
 尽情	jnqy
 仅	jnr
-金	jnr
 金	jnra
 今	jnra
 筋肉	jnrb
@@ -27776,7 +27769,6 @@ I盘	ipj
 觉醒	jtxy
 街谈巷议	jtxy
 诀	jty
-谲	jty
 诀	jtyd
 诀	jtyg
 交通银行	jtyh
@@ -27964,8 +27956,8 @@ I盘	ipj
 剧烈	julx
 近水楼台先得月	july
 橘	jum
-桔	jum
 局麻	juma
+桔	jumj
 驹	jumj
 榉	jumj
 椐	jumj
@@ -28028,7 +28020,6 @@ I盘	ipj
 居所	juso
 嚼舌头	jut
 精神头	jut
-坥	jut
 剧透	jutb
 巨头	jutb
 锯条	jutc
@@ -28037,6 +28028,7 @@ I盘	ipj
 具体	juti
 巨贪	jutj
 剧坛	jutj
+坥	jutq
 九省通衢	jutq
 剧团	jutr
 剧痛	juts
@@ -31323,7 +31315,7 @@ I盘	ipj
 快捷	kyjx
 块茎	kyjy
 看一看	kyk
-哙	kyk
+哙	kykh
 快看	kykj
 可有可无	kykw
 快言快语	kyky
@@ -33776,7 +33768,6 @@ I盘	ipj
 抡起	lpqi
 伦琴	lpqn
 伦	lpr
-仑	lpr
 仑	lprb
 伦	lprl
 纶	lps
@@ -39951,7 +39942,6 @@ I盘	ipj
 蹑足	nxzu
 那样	ny
 宁	nyb
-甯	nyb
 拧巴	nyba
 捏一把汗	nybh
 凝碧	nybi
@@ -41897,7 +41887,6 @@ I盘	ipj
 扑哧	puii
 拍手称快	puik
 铺	puj
-镨	puj
 普教	pujc
 普降	pujd
 镤	pujd
@@ -44562,7 +44551,6 @@ I盘	ipj
 千挑万选	qtwx
 缺位	qtwz
 恪	qtx
-悫	qtx
 恪	qtxg
 缺席	qtxi
 悫	qtxk
@@ -45323,7 +45311,6 @@ I盘	ipj
 倾	qyrq
 轻软	qyrr
 清一色	qys
-綮	qys
 倾洒	qysa
 青涩	qyse
 青色	qyse
@@ -47614,12 +47601,12 @@ I盘	ipj
 三次	sjci
 三餐	sjcj
 三角带	sjd
-潵	sjd
 散打	sjda
 三等	sjdg
 散弹	sjdj
 三代	sjdl
 三点	sjdm
+潵	sjds
 伺机而动	sjed
 散发	sjfa
 四季发财	sjfc
@@ -51788,7 +51775,6 @@ I盘	ipj
 推行	tvxy
 退行	tvxy
 褪	tvy
-颓	tvy
 退养	tvyh
 退役	tvyi
 推移	tvyi
@@ -54061,7 +54047,6 @@ T恤衫	txuj
 时而	uier
 邿	uies
 拾	uif
-拭	uif
 施法	uifa
 事发	uifa
 是否	uifb
@@ -54222,7 +54207,6 @@ T恤衫	txuj
 时	uio
 䏡	uiou
 失	uip
-氏	uip
 矢	uipd
 释	uipf
 氏	uipg
@@ -54433,7 +54417,6 @@ T恤衫	txuj
 山坳	ujao
 生机盎然	ujar
 疝	ujb
-赡	ujb
 神经病	ujb
 生机勃勃	ujbb
 身价百倍	ujbb
@@ -54634,7 +54617,6 @@ T恤衫	txuj
 数据通信	ujtx
 实际上	uju
 手机上	uju
-禅	uju
 禅	ujud
 闪射	ujue
 山神	ujuf
@@ -57850,7 +57832,6 @@ U盘	upj
 只怪	vigy
 只给	vigz
 秩	vih
-稚	vih
 之后	vihb
 滞后	vihb
 纸盒	vihe
@@ -59656,7 +59637,6 @@ U盘	upj
 朱雀	vuqt
 置身其中	vuqv
 住	vur
-伫	vur
 猪肉	vurb
 正是如此	vurc
 主人	vurf
@@ -60698,8 +60678,8 @@ U盘	upj
 微观粒子	wglz
 武功秘籍	wgmj
 亡国奴	wgn
-鹟	wgn
 外刚内柔	wgnr
+鹟	wgnw
 万古千秋	wgqq
 位高权重	wgqv
 外公切线	wgqx
@@ -61773,6 +61753,7 @@ U盘	upj
 舞台艺术	wtyu
 无土栽培	wtzp
 无	wu
+吾	wu
 五	wua
 兀	wuae
 兀	wuag
@@ -61928,7 +61909,6 @@ U盘	upj
 误解	wujx
 武警	wujy
 吴	wuk
-吾	wuk
 无可	wuke
 舞客	wuke
 万事开头难	wukn
@@ -63106,7 +63086,6 @@ U盘	upj
 消协	xcxx
 小型	xcxy
 霄	xcy
-嚣	xcy
 校友	xcyb
 秀才遇到兵	xcyb
 小菜一碟	xcyd
@@ -67077,7 +67056,6 @@ U盘	upj
 一笔勾销	ybgx
 诱拐	ybgy
 也不会	ybh
-黝	ybh
 优厚	ybhb
 一报还一报	ybhb
 幽篁	ybhd
@@ -67096,7 +67074,6 @@ U盘	upj
 黝	ybhy
 黝黑	ybhz
 蚴	ybi
-蝣	ybi
 油茶	ybia
 有仇	ybib
 忧愁	ybib
@@ -68533,7 +68510,6 @@ U盘	upj
 一切	yiqx
 疫情	yiqy
 依	yir
-亿	yir
 亿	yira
 艺人	yirf
 伊人	yirf
@@ -68910,7 +68886,6 @@ U盘	upj
 蜒	yjiy
 蝘	yjiy
 眼镜	yjj
-厣	yjj
 眼角	yjjc
 有奖竞猜	yjjc
 演讲	yjjd
@@ -68918,7 +68893,7 @@ U盘	upj
 远交近攻	yjjg
 演技	yjji
 义结金兰	yjjl
-引頸就戮	yjjl
+引颈就戮	yjjl
 眼见	yjjm
 严禁	yjjn
 严谨	yjjn
@@ -68930,6 +68905,7 @@ U盘	upj
 眼界	yjjx
 眼睛	yjjy
 眼镜	yjjy
+厣	yjjy
 觃	yjjz
 咽	yjk
 眼眶	yjkd
@@ -69824,7 +69800,6 @@ U盘	upj
 阴囊	ynnh
 印尼	ynni
 殷	ynp
-胤	ynp
 银票	ynpc
 胤	ynpg
 荫棚	ynpg
@@ -70672,11 +70647,11 @@ U盘	upj
 庸碌	yslu
 一死了之	yslv
 有什么	ysm
-栐	ysm
 勇猛	ysmg
 泳帽	ysmk
 夜色迷离	ysml
 用命	ysmy
+栐	ysmy
 咏梅	ysmz
 㛚	ysn
 用脑	ysnk
@@ -70976,6 +70951,7 @@ U盘	upj
 趯	ytzv
 跃	ytzy
 与	yu
+御	yu
 于	yua
 聿	yuaa
 雨	yuad
@@ -71407,7 +71383,6 @@ U盘	upj
 衣食无忧	yuwy
 誉为	yuwz
 愈	yux
-御	yux
 艺术细胞	yuxb
 用舍行藏	yuxc
 预想	yuxd
@@ -72107,7 +72082,6 @@ U盘	upj
 罂粟	yysu
 悠悠岁月	yysy
 有一天	yyt
-茔	yyt
 迎头	yytb
 茔	yytb
 硬糖	yyth


### PR DESCRIPTION
- 删除50余个3码次选字（大部分为冷僻字），避免在默认模式中全码被defer导致输入体验不佳
- 将御、吾提为2简次选
- 修正简体码表中的“引颈就戮”为简体（原为繁体）